### PR TITLE
[Fix] Fix DemoHTML2PDF crash on api 21 device

### DIFF
--- a/DemoHTML2PDF/app/src/main/java/com/pdftron/demohtml2pdf/MainActivity.kt
+++ b/DemoHTML2PDF/app/src/main/java/com/pdftron/demohtml2pdf/MainActivity.kt
@@ -8,7 +8,6 @@ import com.pdftron.pdf.config.ViewerConfig
 import com.pdftron.pdf.controls.DocumentActivity
 import com.pdftron.pdf.utils.HTML2PDF
 
-
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,7 +45,7 @@ class MainActivity : AppCompatActivity() {
                 "</body>\n" +
                 "</html>"
 
-        val html2PDF = HTML2PDF(this)
+        val html2PDF = HTML2PDF(this.applicationContext)
         html2PDF.setOutputFolder(this.cacheDir)
         html2PDF.setHTML2PDFListener(object : HTML2PDF.HTML2PDFListener {
             override fun onConversionFinished(pdfOutput: String, isLocal: Boolean) {


### PR DESCRIPTION
Fix DemoHTML2PDF crash on api 21 device

## Support Ticket

## Issues Closed or Referenced
closes #5298

## Description of Changes
- "this.applicationContext" is added to the WebView constructor to avoid crashing on API 21

## Screenshots

