### PR TITLE
Overflow menu shows a blank dialog then animates

### DIFF
--- a/CustomUI/app/src/main/res/values/styles.xml
+++ b/CustomUI/app/src/main/res/values/styles.xml
@@ -38,12 +38,14 @@
         <item name="android:spinnerDropDownItemStyle" tools:targetApi="23">
             @style/SampleTextViewSpinnerDropDownItem
         </item>
-        
+
+
         <!-- Component styles and themes -->
         <item name="pt_toolbar_popup_theme">@style/AppTheme.ToolbarOverflow</item>
+
+        <item name="actionOverflowButtonStyle">@style/SampleActionOverflowButtonStyle</item>
         <item name="toolbarStyle">@style/ToolbarStyle</item>
         <item name="toolbarNavigationButtonStyle">@style/CustomToolbarButtonNavigationStyle</item>
-        <item name="actionOverflowButtonStyle">@style/SampleActionOverflowButtonStyle</item>
         <item name="pt_pdf_tab_layout_style">@style/SamplePdfTabLayoutStyle</item>
         <item name="pt_toolbar_style">@style/SampleToolbarStyle</item>
         <item name="pt_toolbar_theme">@style/FragmentToolbarTheme</item>
@@ -88,7 +90,7 @@
     </style>
 
     <style name="AppTheme.ToolbarOverflow" parent="ToolbarPopupTheme">
-        <item name="android:background">#ffd1dc</item>
+        <item name="android:itemBackground">#ffd1dc</item>
         <item name="android:textColor">#000000</item>
     </style>
 
@@ -115,7 +117,6 @@
 
     <!-- Theme for all toolbars, including browsers -->
     <style name="FragmentToolbarTheme" parent="ToolbarTheme">
-        <item name="android:background">@color/background_color</item>  <!-- Affects toolbar action button background and overflow menu background-->
         <item name="titleTextColor">@color/body_text_color</item>
         <item name="colorControlNormal">@color/body_text_color</item>
         <item name="iconTint">@color/body_text_color</item>


### PR DESCRIPTION
Removed android:background from AppTheme.ToolbarOverflow style and added android:itemBackground
Removed android:background from FragmentToolbarThemestyle as it conflicts with itemBackground in the overflow menu